### PR TITLE
fix: add .js extension to all imports

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -4,6 +4,8 @@
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
+    // https://github.com/import-js/eslint-plugin-import/issues/2170#issuecomment-889657579
+    "import/no-unresolved": "off",
     "max-classes-per-file": "off",
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-restricted-syntax": [

--- a/client/packages/client-common/src/ConnectionIndicator.ts
+++ b/client/packages/client-common/src/ConnectionIndicator.ts
@@ -17,7 +17,7 @@
 import { html, LitElement } from 'lit';
 import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { ConnectionState, ConnectionStateStore } from './ConnectionState';
+import { ConnectionState, ConnectionStateStore } from './ConnectionState.js';
 
 const DEFAULT_STYLE_ID = 'css-loading-indicator';
 

--- a/client/packages/client-common/src/index.ts
+++ b/client/packages/client-common/src/index.ts
@@ -1,2 +1,2 @@
-export * from './ConnectionState';
-export * from './ConnectionIndicator';
+export * from './ConnectionState.js';
+export * from './ConnectionIndicator.js';

--- a/client/packages/client-fusion/src/Authentication.ts
+++ b/client/packages/client-fusion/src/Authentication.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareClass, MiddlewareContext, MiddlewareNext } from './Connect';
+import type { MiddlewareClass, MiddlewareContext, MiddlewareNext } from './Connect.js';
 
 const $wnd = window as any;
 

--- a/client/packages/client-fusion/src/form/Binder.ts
+++ b/client/packages/client-fusion/src/form/Binder.ts
@@ -1,13 +1,13 @@
 // TODO: Fix dependency cycle
 
 // eslint-disable-next-line import/no-cycle
-import { BinderNode } from './BinderNode';
+import { BinderNode } from './BinderNode.js';
 // eslint-disable-next-line import/no-cycle
-import { _parent, AbstractModel, ModelConstructor } from './Models';
+import { _parent, AbstractModel, ModelConstructor } from './Models.js';
 // eslint-disable-next-line import/no-cycle
-import { runValidator, ServerValidator, ValidationError, Validator, ValueError } from './Validation';
+import { runValidator, ServerValidator, ValidationError, Validator, ValueError } from './Validation.js';
 // eslint-disable-next-line import/no-cycle
-import { FieldStrategy, getDefaultFieldStrategy } from './Field';
+import { FieldStrategy, getDefaultFieldStrategy } from './Field.js';
 
 const _submitting = Symbol('submitting');
 const _defaultValue = Symbol('defaultValue');

--- a/client/packages/client-fusion/src/form/BinderNode.ts
+++ b/client/packages/client-fusion/src/form/BinderNode.ts
@@ -15,7 +15,7 @@
  */
 // TODO: Fix dependency cycle
 
-import type { Binder } from './Binder';
+import type { Binder } from './Binder.js';
 // eslint-disable-next-line import/no-cycle
 import {
   _binderNode,
@@ -29,8 +29,8 @@ import {
   ModelConstructor,
   ModelValue,
   ObjectModel,
-} from './Models';
-import type { Validator, ValueError } from './Validation';
+} from './Models.js';
+import type { Validator, ValueError } from './Validation.js';
 
 const _ownErrors = Symbol('ownErrorsSymbol');
 const _visited = Symbol('visited');

--- a/client/packages/client-fusion/src/form/Field.ts
+++ b/client/packages/client-fusion/src/form/Field.ts
@@ -1,6 +1,6 @@
 import { ElementPart, noChange, nothing, PropertyPart } from 'lit';
 import { directive, Directive, DirectiveParameters, PartInfo, PartType } from 'lit/directive.js';
-import { _fromString, AbstractModel, getBinderNode } from './Models';
+import { _fromString, AbstractModel, getBinderNode } from './Models.js';
 
 interface Field {
   required: boolean;

--- a/client/packages/client-fusion/src/form/Models.ts
+++ b/client/packages/client-fusion/src/form/Models.ts
@@ -1,10 +1,10 @@
 // TODO: Fix dependency cycle
 
-import isNumeric from 'validator/es/lib/isNumeric';
+import isNumeric from 'validator/es/lib/isNumeric.js';
 // eslint-disable-next-line import/no-cycle
-import { BinderNode } from './BinderNode';
-import type { Validator } from './Validation';
-import { IsNumber } from './Validators';
+import { BinderNode } from './BinderNode.js';
+import type { Validator } from './Validation.js';
+import { IsNumber } from './Validators.js';
 
 export const _ItemModel = Symbol('ItemModel');
 export const _parent = Symbol('parent');

--- a/client/packages/client-fusion/src/form/Validation.ts
+++ b/client/packages/client-fusion/src/form/Validation.ts
@@ -1,10 +1,10 @@
 // TODO: Fix dependency cycle
 
-import type { Binder } from './Binder';
+import type { Binder } from './Binder.js';
 // eslint-disable-next-line import/no-cycle
-import { AbstractModel, getBinderNode, NumberModel } from './Models';
+import { AbstractModel, getBinderNode, NumberModel } from './Models.js';
 // eslint-disable-next-line import/no-cycle
-import { Required } from './Validators';
+import { Required } from './Validators.js';
 
 export interface ValueError<T> {
   property: string | AbstractModel<any>;

--- a/client/packages/client-fusion/src/form/Validators.ts
+++ b/client/packages/client-fusion/src/form/Validators.ts
@@ -1,14 +1,14 @@
-import isAfter from 'validator/es/lib/isAfter';
-import isBefore from 'validator/es/lib/isBefore';
-import isBoolean from 'validator/es/lib/isBoolean';
-import isDecimal from 'validator/es/lib/isDecimal';
-import isEmail from 'validator/es/lib/isEmail';
-import isFloat from 'validator/es/lib/isFloat';
-import isLength from 'validator/es/lib/isLength';
-import isNumeric from 'validator/es/lib/isNumeric';
-import matches from 'validator/es/lib/matches';
-import toFloat from 'validator/es/lib/toFloat';
-import type { Validator } from './Validation';
+import isAfter from 'validator/es/lib/isAfter.js';
+import isBefore from 'validator/es/lib/isBefore.js';
+import isBoolean from 'validator/es/lib/isBoolean.js';
+import isDecimal from 'validator/es/lib/isDecimal.js';
+import isEmail from 'validator/es/lib/isEmail.js';
+import isFloat from 'validator/es/lib/isFloat.js';
+import isLength from 'validator/es/lib/isLength.js';
+import isNumeric from 'validator/es/lib/isNumeric.js';
+import matches from 'validator/es/lib/matches.js';
+import toFloat from 'validator/es/lib/toFloat.js';
+import type { Validator } from './Validation.js';
 
 interface ValidatorAttributes {
   message?: string;

--- a/client/packages/client-fusion/src/form/index.ts
+++ b/client/packages/client-fusion/src/form/index.ts
@@ -1,8 +1,8 @@
-export * from './Binder';
-export * from './Field';
-export * from './Models';
-export * from './Validation';
-export * from './Validators';
+export * from './Binder.js';
+export * from './Field.js';
+export * from './Models.js';
+export * from './Validation.js';
+export * from './Validators.js';
 
 const $wnd = window as any;
 $wnd.Vaadin = $wnd.Vaadin || {};

--- a/client/packages/client-fusion/src/index.ts
+++ b/client/packages/client-fusion/src/index.ts
@@ -1,2 +1,2 @@
-export * from './Authentication';
-export * from './Connect';
+export * from './Authentication.js';
+export * from './Connect.js';


### PR DESCRIPTION
## Description

1. Updated all the import statements to use `.js` extension, including those for `valiidator` package.
2. Disabled `import/no-unresolved` ESLint rule as it does not play well with ES modules (see comment).

Fixes #71

## Type of change

- Internal change