### PR TITLE
chore(frontend): more fixes in order to make the release runnable

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Bump New Version
         run: sh scripts/bump.sh
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_RELEASE_TOKEN: ${{ secrets.GITHUB_RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION_TAG: ${{ github.event.release.tag_name }}
       - name: Publish

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Bump New Version
         run: sh scripts/bump.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION_TAG: ${{ github.event.release.tag_name }}
       - name: Publish

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Bump New Version
         run: sh scripts/bump.sh
         env:
-          GITHUB_RELEASE_TOKEN: ${{ secrets.GITHUB_RELEASE_TOKEN }}
+          GITHUB_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION_TAG: ${{ github.event.release.tag_name }}
       - name: Publish

--- a/frontend/scripts/bump.sh
+++ b/frontend/scripts/bump.sh
@@ -5,7 +5,7 @@ branch=main
 # shellcheck disable=SC2139
 alias ghr="curl https://api.github.com/repos/$REPO/branches/$branch/protection \
   -H 'Accept: application/vnd.github.v3+json' \
-  -H 'Authorization: token $GITHUB_TOKEN' \
+  -H 'Authorization: token $RELEASE_TOKEN' \
   -s"
 
 node scripts/update-package-versions.js "$VERSION_TAG"
@@ -23,6 +23,6 @@ remapped=$(node scripts/protection-remap.js "$protection_config")
 
 ghr -X PUT -d "$(echo "$remapped" | sed '$s/"enforce_admins":true/"enforce_admins":false/')" > /dev/null
 
-git push https://vaadin-bot:"$GITHUB_TOKEN"@github.com/"$REPO".git HEAD:$branch
+git push https://vaadin-bot:"$RELEASE_TOKEN"@github.com/"$REPO".git HEAD:$branch
 
 ghr -X PUT -d "$remapped" > /dev/null

--- a/frontend/scripts/bump.sh
+++ b/frontend/scripts/bump.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# Fails the script if any command failed or any variable is unset
 set -eu
 
 branch=main
@@ -7,7 +8,7 @@ branch=main
 # shellcheck disable=SC2139
 alias ghr="curl https://api.github.com/repos/$REPO/branches/$branch/protection \
   -H 'Accept: application/vnd.github.v3+json' \
-  -H 'Authorization: token $RELEASE_TOKEN' \
+  -H 'Authorization: token $GITHUB_RELEASE_TOKEN' \
   -s"
 
 node scripts/update-package-versions.js "$VERSION_TAG"
@@ -25,6 +26,6 @@ remapped=$(node scripts/protection-remap.js "$protection_config")
 
 ghr -X PUT -d "$(echo "$remapped" | sed '$s/"enforce_admins":true/"enforce_admins":false/')" > /dev/null
 
-git push https://vaadin-bot:"$RELEASE_TOKEN"@github.com/"$REPO".git HEAD:$branch
+git push https://vaadin-bot:"$GITHUB_RELEASE_TOKEN"@github.com/"$REPO".git HEAD:$branch
 
 ghr -X PUT -d "$remapped" > /dev/null

--- a/frontend/scripts/bump.sh
+++ b/frontend/scripts/bump.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eu
+
 branch=main
 
 # shellcheck disable=SC2139


### PR DESCRIPTION
- Rename GITHUB_TOKEN -> RELEASE_TOKEN in case GitHub overwrites the variable by a different value
- Make bash script falling on any command error