### PR TITLE
chore(frontend): make publishing more correct

### DIFF
--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -41,9 +41,11 @@ jobs:
           GIT_RELEASE_TOKEN: ${{ secrets.GIT_RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
           VERSION_TAG: ${{ github.event.release.tag_name }}
+      - name: Re-build New Version
+        run: npm run build
       - name: Publish
         run: |
-          npx lerna publish --dist-tag \
+          npx lerna publish from-package --dist-tag \
             "$([[ ${{ github.event.release.tag_name }} =~ alpha|beta|rc ]] && echo "next" || echo "latest")"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/frontend/scripts/bump/update-package-versions.js
+++ b/frontend/scripts/bump/update-package-versions.js
@@ -37,11 +37,16 @@ async function updatePackageRegistrations() {
   await Promise.all(
     packages.map(async (_package) => {
       const indexFile = resolve(packagesRoot, _package, 'src/index.ts');
-      const content = await readFile(indexFile, 'utf8');
-      const updated = content.replace(versionPattern, `version: /* updated-by-script */ '${version}',`);
-      await writeFile(indexFile, updated, 'utf8');
+      const packageFile = resolve(packagesRoot, _package, 'package.json');
+      const [indexContent, packageContent] = await Promise.all([
+        readFile(indexFile, 'utf8'),
+        readFile(packageFile, 'utf8'),
+      ]);
+      const indexUpdated = indexContent.replace(versionPattern, `version: /* updated-by-script */ '${version}',`);
+      const packageUpdated = JSON.stringify({ ...JSON.parse(packageContent), version }, null, 2);
+      await Promise.all([writeFile(indexFile, indexUpdated, 'utf8'), writeFile(packageFile, packageUpdated, 'utf8')]);
 
-      log(`@vaadin/${_package} registration updated`);
+      log(`@vaadin/${_package} version and registration updated`);
     })
   );
 }


### PR DESCRIPTION
- Update `version` in `package.json` for packages.
- Re-build version after bumping to get correct versions in built code
- Use correct publishing for Lerna