### PR TITLE
fix: NumberModel should read empty string as undefined

### DIFF
--- a/frontend/packages/form/src/Models.ts
+++ b/frontend/packages/form/src/Models.ts
@@ -92,7 +92,7 @@ export class BooleanModel extends PrimitiveModel<boolean> implements HasFromStri
   [_fromString] = Boolean;
 }
 
-export class NumberModel extends PrimitiveModel<number> implements HasFromString<number> {
+export class NumberModel extends PrimitiveModel<number> implements HasFromString<number | undefined> {
   static createEmptyValue = Number;
 
   constructor(
@@ -105,7 +105,10 @@ export class NumberModel extends PrimitiveModel<number> implements HasFromString
     super(parent, key, optional, new IsNumber(optional), ...validators);
   }
 
-  [_fromString](str: string): number {
+  [_fromString](str: string): number | undefined {
+    // Returning undefined is needed to support passing the validation when the value of an optional number field is
+    // an empty string
+    if (str === '') return undefined;
     return isNumeric(str) ? Number.parseFloat(str) : NaN;
   }
 }

--- a/frontend/packages/form/test/Field.test.ts
+++ b/frontend/packages/form/test/Field.test.ts
@@ -271,11 +271,11 @@ describe('form/Field', () => {
       });
 
       it('should update binder value on typing', async () => {
-        const cases: Array<[string, number]> = [
+        const cases: Array<[string, number | undefined]> = [
           ['1', 1],
           ['1.', NaN], // not allowed format
           ['1.2', 1.2],
-          ['', NaN],
+          ['', undefined],
           ['not a number', NaN],
           ['.', NaN],
           ['.1', 0.1],
@@ -421,11 +421,11 @@ describe('form/Field', () => {
       });
 
       it('should update binder value on typing', async () => {
-        const cases: Array<[string, number]> = [
+        const cases: Array<[string, number | undefined]> = [
           ['1', 1],
           ['1.', NaN], // not allowed format
           ['1.2', 1.2],
-          ['', NaN],
+          ['', undefined],
           ['not a number', NaN],
           ['.', NaN],
           ['.1', 0.1],

--- a/frontend/packages/form/test/Model.test.ts
+++ b/frontend/packages/form/test/Model.test.ts
@@ -61,14 +61,14 @@ describe('form/Model', () => {
     });
 
     describe('_fromString', () => {
-      let fromString: (str: string) => number;
+      let fromString: (str: string) => number | undefined;
 
       beforeEach(() => {
         fromString = binder.model.fieldNumber[_fromString];
       });
 
       it('should disallow empty string', async () => {
-        expect(fromString('')).to.satisfy(Number.isNaN);
+        expect(fromString('')).to.equal(undefined);
       });
 
       it('should integer format', async () => {


### PR DESCRIPTION
Related to https://github.com/vaadin/spring/issues/904.
Porting the fix in https://github.com/vaadin/flow/pull/11169.