### PR TITLE
chore: minor improvements, mainly linting fixes

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -25,6 +25,7 @@
     ],
 
     "no-unused-expressions": "off",
-    "chai-friendly/no-unused-expressions": "error"
+    "chai-friendly/no-unused-expressions": "error",
+    "lit/quoted-expressions": "off" // Needs to be off for element expressions, but would be nice to have on for other kind of expressions
   }
 }

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -4,6 +4,7 @@
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-explicit-any": "off",
     // https://github.com/import-js/eslint-plugin-import/issues/2170#issuecomment-889657579
     "import/no-unresolved": "off",
     "max-classes-per-file": "off",

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -5,6 +5,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     // https://github.com/import-js/eslint-plugin-import/issues/2170#issuecomment-889657579
     "import/no-unresolved": "off",
     "max-classes-per-file": "off",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,7 +15,7 @@ The collection of frontend utilities used by Vaadin Flow and Fusion.
 You can download the project and run tests using the following commands:
 ```bash
 $ git clone https://github.com/vaadin/fusion.git
-$ cd fusion
+$ cd fusion/frontend
 $ npm install
 $ npm run build
 $ npm test

--- a/frontend/packages/form/package.json
+++ b/frontend/packages/form/package.json
@@ -12,11 +12,11 @@
   ],
   "scripts": {
     "build": "tsc --isolatedModules",
-    "lint": "eslint --fix src/**/*.ts",
+    "lint": "eslint --fix src/**/*.ts test/**/*.ts",
     "test": "web-test-runner \"test/**/*.test.ts\" --config ../../web-test-runner.config.js",
     "test:coverage": "npm run test -- --coverage",
     "test:watch": "npm run test -- --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit --project test/tsconfig.json"
   },
   "exports": {
     ".": {

--- a/frontend/packages/form/test/Field.test.ts
+++ b/frontend/packages/form/test/Field.test.ts
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { LitElement, nothing, render } from 'lit';
 import { html, unsafeStatic } from 'lit/static-html.js';
 import { customElement, query } from 'lit/decorators.js';
-import type { BinderNode } from '../src/form/BinderNode';
+import type { BinderNode } from '../src/BinderNode.js';
 // API to test
 import {
   Binder,

--- a/frontend/packages/form/test/Validation.test.ts
+++ b/frontend/packages/form/test/Validation.test.ts
@@ -150,7 +150,7 @@ describe('form/Validation', () => {
           // do nothing
         });
         expect.fail();
-      } catch (error) {
+      } catch (error: any) {
         expect(error.errors.length).to.gt(0);
       }
     });
@@ -163,7 +163,7 @@ describe('form/Validation', () => {
           throw new Error('whatever');
         });
         expect.fail();
-      } catch (error) {
+      } catch (error: any) {
         expect(error.message).to.be.equal('whatever');
       }
     });
@@ -186,7 +186,7 @@ describe('form/Validation', () => {
           };
         });
         expect.fail();
-      } catch (error) {
+      } catch (error: any) {
         expect(error.errors[0].message).to.be.equal('custom message');
         expect(error.errors[0].value).to.be.equal('baz');
         expect(error.errors[0].property).to.be.equal('foo');
@@ -210,7 +210,7 @@ describe('form/Validation', () => {
           };
         });
         expect.fail();
-      } catch (error) {
+      } catch (error: any) {
         expect(error.errors[0].message).to.be.equal('Custom server message');
         expect(error.errors[0].value).to.be.undefined;
         expect(error.errors[0].property).to.be.equal('bar');

--- a/frontend/packages/form/test/tsconfig.json
+++ b/frontend/packages/form/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../"
+  },
+  "include": ["."]
+}

--- a/frontend/packages/form/tsconfig.json
+++ b/frontend/packages/form/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "."
+    "outDir": ".",
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["!src/**/*"]

--- a/frontend/packages/fusion-frontend/package.json
+++ b/frontend/packages/fusion-frontend/package.json
@@ -12,11 +12,11 @@
   ],
   "scripts": {
     "build": "tsc --isolatedModules",
-    "lint": "eslint --fix src/**/*.ts",
+    "lint": "eslint --fix src/**/*.ts test/**/*.ts",
     "test": "web-test-runner \"test/**/*.test.ts\" --config ../../web-test-runner.config.js",
     "test:coverage": "npm run test -- --coverage",
     "test:watch": "npm run test -- --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit --project test/tsconfig.json"
   },
   "exports": {
     ".": {

--- a/frontend/packages/fusion-frontend/test/Authentication.test.ts
+++ b/frontend/packages/fusion-frontend/test/Authentication.test.ts
@@ -15,7 +15,6 @@ import {
 // `connectClient.call` adds the host and context to the endpoint request.
 // we need to add this origin when configuring fetch-mock
 const base = window.location.origin;
-const $wnd = window as any;
 
 describe('Authentication', () => {
   const requestHeaders: Record<string, string> = {};

--- a/frontend/packages/fusion-frontend/test/Authentication.test.ts
+++ b/frontend/packages/fusion-frontend/test/Authentication.test.ts
@@ -28,7 +28,6 @@ describe('Authentication', () => {
     'Spring-CSRF-header': TET_SPRING_CSRF_HEADER_NAME,
     'Spring-CSRF-token': TEST_SPRING_CSRF_TOKEN_VALUE,
   };
-  let originalCookie;
 
   function verifySpringCsrfToken(token: string) {
     expect(document.head.querySelector('meta[name="_csrf"]')!.getAttribute('content')).to.equal(token);
@@ -39,13 +38,11 @@ describe('Authentication', () => {
 
   beforeEach(() => {
     setupSpringCsrfMetaTags();
-    originalCookie = document.cookie;
     requestHeaders[TET_SPRING_CSRF_HEADER_NAME] = TEST_SPRING_CSRF_TOKEN_VALUE;
   });
   afterEach(() => {
     // @ts-ignore
     delete window.Vaadin.TypeScript;
-    document.cookie = originalCookie;
     clearSpringCsrfMetaTags();
   });
 

--- a/frontend/packages/fusion-frontend/test/Connect.test.ts
+++ b/frontend/packages/fusion-frontend/test/Connect.test.ts
@@ -127,8 +127,8 @@ describe('ConnectClient', () => {
     let client: ConnectClient;
 
     beforeEach(() => {
-      fetchMock.post(base + '/connect/FooEndpoint/fooMethod', { fooData: 'foo' });
-      fetchMock.post(base + '/connect/FooEndpoint/fooMethodWithNullValue', { fooData: 'foo', propWithNullValue: null });
+      fetchMock.post(`${base}/connect/FooEndpoint/fooMethod`, { fooData: 'foo' });
+      fetchMock.post(`${base}/connect/FooEndpoint/fooMethodWithNullValue`, { fooData: 'foo', propWithNullValue: null });
       client = new ConnectClient();
     });
 
@@ -237,8 +237,7 @@ describe('ConnectClient', () => {
 
         await client.call('FooEndpoint', 'fooMethod');
 
-        const headers = fetchMock.lastOptions().headers;
-        expect(headers).to.deep.include({
+        expect(fetchMock.lastOptions()?.headers).to.deep.include({
           [TET_SPRING_CSRF_HEADER_NAME]: TEST_SPRING_CSRF_TOKEN_VALUE,
         });
       } finally {
@@ -253,8 +252,7 @@ describe('ConnectClient', () => {
 
         await client.call('FooEndpoint', 'fooMethod');
 
-        const headers = fetchMock.lastOptions().headers;
-        expect(headers).to.deep.include({
+        expect(fetchMock.lastOptions()?.headers).to.deep.include({
           [TET_SPRING_CSRF_HEADER_NAME]: TEST_SPRING_CSRF_TOKEN_VALUE,
         });
       } finally {
@@ -269,9 +267,7 @@ describe('ConnectClient', () => {
 
         await client.call('FooEndpoint', 'fooMethod');
 
-        const headers = fetchMock.lastOptions().headers;
-
-        expect(headers).to.deep.include({
+        expect(fetchMock.lastOptions()?.headers).to.deep.include({
           [VAADIN_CSRF_HEADER.toLowerCase()]: csrfToken,
         });
       } finally {
@@ -286,7 +282,7 @@ describe('ConnectClient', () => {
 
     it('should transform null value to undefined from response JSON data', async () => {
       const data = await client.call('FooEndpoint', 'fooMethodWithNullValue');
-      expect(data['propWithNullValue']).to.be.undefined;
+      expect(data.propWithNullValue).to.be.undefined;
       expect(data).to.deep.equal({ fooData: 'foo' });
     });
 

--- a/frontend/packages/fusion-frontend/test/Connect.test.ts
+++ b/frontend/packages/fusion-frontend/test/Connect.test.ts
@@ -125,18 +125,15 @@ describe('ConnectClient', () => {
 
   describe('call method', () => {
     let client: ConnectClient;
-    let originalCookie;
 
     beforeEach(() => {
       fetchMock.post(base + '/connect/FooEndpoint/fooMethod', { fooData: 'foo' });
       fetchMock.post(base + '/connect/FooEndpoint/fooMethodWithNullValue', { fooData: 'foo', propWithNullValue: null });
       client = new ConnectClient();
-      originalCookie = document.cookie;
     });
 
     afterEach(() => {
       fetchMock.restore();
-      document.cookie = originalCookie;
     });
 
     it('should require 2 arguments', async () => {

--- a/frontend/packages/fusion-frontend/test/SpringCsrfTestUtils.test.ts
+++ b/frontend/packages/fusion-frontend/test/SpringCsrfTestUtils.test.ts
@@ -33,10 +33,10 @@ export function verifySpringCsrfTokenIsCleared() {
   expect(document.head.querySelector('meta[name="_csrf_header"]')).to.be.null;
 }
 
-export function setCookie(name: string, value: string) {
-  document.cookie = name + '=' + value;
+export function setCookie(name: string, value: string): void {
+  document.cookie = `${name}=${value}`;
 }
 
-export function clearCookie(name: string) {
-  setCookie(name, '');
+export function clearCookie(name: string): void {
+  document.cookie = `${name}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 }

--- a/frontend/packages/fusion-frontend/test/SpringCsrfTestUtils.test.ts
+++ b/frontend/packages/fusion-frontend/test/SpringCsrfTestUtils.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@open-wc/testing';
+
 export const TET_SPRING_CSRF_HEADER_NAME = 'x-xsrf-token';
 export const TEST_SPRING_CSRF_TOKEN_VALUE = 'spring-csrf-token';
 export const TEST_VAADIN_CSRF_TOKEN_VALUE = 'vaadin-csrf-token';

--- a/frontend/packages/fusion-frontend/test/tsconfig.json
+++ b/frontend/packages/fusion-frontend/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../"
+  },
+  "include": ["."]
+}

--- a/frontend/packages/fusion-frontend/tsconfig.json
+++ b/frontend/packages/fusion-frontend/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "."
+    "outDir": ".",
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["!src/**/*"]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,5 +15,5 @@
     "importsNotUsedAsValues": "error",
     "useUnknownInCatchVariables": true
   },
-  "include": ["packages/**"]
+  "include": ["packages/**/*"]
 }


### PR DESCRIPTION
### Summary

Enable linting and type checking for test sources. Get rid of all current lint issues (also warnings). Fix command in readme and few minor refactorings.

### Details:

chore(readme): fix command in readme

- The main `package.json` is under the `frontend` directory and not in repository root. Fix the related `cd` command in the readme.

chore: improve IDE linting config for tests

- Add tsconfigs to the test directories to prevent linting errors in VS Code related to global mocha methods like describe being undefined. The test sources need to be included in some tsconfig for the TS integration in the IDE to use e.g. the mocha type declarations in the context of the test files.

chore: fix syntax error in `tsconfig.json`

chore: enable linting and type checking for test sources

test: improve cookie handling utils

- The old version of `clearCookie()` that just sets an empty value to a cookie doesn't actually remove the cookie. It just makes it so the cookie has an empty value but it still exists. To actually remove a cookie it needs to be set with an `Expires` option in the past.

test: remove unused const

test: remove non-functional cookie restoration code

- This is not a working way to save and restore cookies using `document.cookie`. This is also not needed since the tests that are setting cookies are also taking care of clearing them using `try..finally` and `clearCookie()`.

chore: turn off lint rule `lit/quoted-expressions`

- This rule needs to be off for element expressions. Would be nice if there was a rule to enable this only for the other type of expressions like attribute, property and event handler bindings.

chore: turn off lint rule `@typescript-eslint/no-explicit-any`

- We are currently using explicit any in most source files so let's ignore this for now so we can better focus on not introducing new lint warnings/errors.

chore: turn off lint rule `@typescript-eslint/explicit-module-boundary-types`

test: fix linting issues in tests