### PR TITLE
feat: validation message interpolation

### DIFF
--- a/packages/ts/form/src/Binder.ts
+++ b/packages/ts/form/src/Binder.ts
@@ -5,7 +5,14 @@ import { BinderNode } from './BinderNode.js';
 // eslint-disable-next-line import/no-cycle
 import { _parent, AbstractModel, ModelConstructor } from './Models.js';
 // eslint-disable-next-line import/no-cycle
-import { runValidator, ServerValidator, ValidationError, Validator, ValueError } from './Validation.js';
+import {
+  InterpolateMessageCallback,
+  runValidator,
+  ServerValidator,
+  ValidationError,
+  Validator,
+  ValueError,
+} from './Validation.js';
 // eslint-disable-next-line import/no-cycle
 import { FieldStrategy, getDefaultFieldStrategy } from './Field.js';
 
@@ -46,6 +53,8 @@ export class Binder<T, M extends AbstractModel<T>> extends BinderNode<T, M> {
 
   private [_validations]: Map<AbstractModel<any>, Map<Validator<any>, Promise<ReadonlyArray<ValueError<any>>>>> =
     new Map();
+
+  public static interpolateMessageCallback?: InterpolateMessageCallback<any>;
 
   /**
    *
@@ -208,7 +217,7 @@ export class Binder<T, M extends AbstractModel<T>> extends BinderNode<T, M> {
       return modelValidations.get(validator) as Promise<ReadonlyArray<ValueError<NT>>>;
     }
 
-    const promise = runValidator(model, validator);
+    const promise = runValidator(model, validator, Binder.interpolateMessageCallback);
     modelValidations.set(validator, promise);
     const valueErrors = await promise;
 

--- a/packages/ts/form/test/TestModels.ts
+++ b/packages/ts/form/test/TestModels.ts
@@ -5,6 +5,7 @@ import {
   ArrayModel,
   BooleanModel,
   ModelConstructor,
+  NotBlank,
   NumberModel,
   ObjectModel,
   Pattern,
@@ -170,5 +171,31 @@ export class EmployeeModel<T extends Employee = Employee> extends IdEntityModel<
 
   public get colleagues() {
     return this[_getPropertyModel]('colleagues', ArrayModel, [true, EmployeeModel, [false]]);
+  }
+}
+
+export interface TestMessageInterpolationEntity {
+  stringMinSize: string;
+  stringNotBlank: string;
+}
+export class TestMessageInterpolationModel<
+  T extends TestMessageInterpolationEntity = TestMessageInterpolationEntity,
+> extends ObjectModel<T> {
+  public static override createEmptyValue: () => TestMessageInterpolationEntity;
+
+  public get stringMinSize() {
+    return this[_getPropertyModel]('stringMinSize', StringModel, [
+      false,
+      new Size({ min: 4 }),
+      new Required(),
+    ]) as StringModel;
+  }
+
+  public get stringNotBlank() {
+    return this[_getPropertyModel]('stringNotBlank', StringModel, [
+      false,
+      new NotBlank(),
+      new Required(),
+    ]) as StringModel;
   }
 }


### PR DESCRIPTION
## Description

Add API for enabling interpolation of validation messages (e.g. for localization purposes) via a static property interpolateMessageCallback on Binder.

Fixes #127

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
