### PR TITLE
fix(form): support empty Size validator

### DIFF
--- a/packages/ts/form/src/Validators.ts
+++ b/packages/ts/form/src/Validators.ts
@@ -274,7 +274,7 @@ export class Size extends AbstractValidator<string> {
 
   public max: number;
 
-  public constructor(attrs: SizeAttributes) {
+  public constructor(attrs: SizeAttributes = {}) {
     super({ message: `size must be between ${_min(attrs)} and ${_max(attrs)}`, ...attrs });
     this.min = _min(attrs);
     this.max = _max(attrs);

--- a/packages/ts/form/test/Validators.test.ts
+++ b/packages/ts/form/test/Validators.test.ts
@@ -227,6 +227,14 @@ describe('form/Validators', () => {
     assert.isNotTrue(noMinValidator.impliesRequired);
     const minZeroValidator = new Size({ min: 0, max: 3 });
     assert.isNotTrue(minZeroValidator.impliesRequired);
+    const noValueSizeValidator = new Size({});
+    assert.isNotTrue(noValueSizeValidator.impliesRequired);
+    assert.isTrue(noValueSizeValidator.validate(''));
+    assert.isTrue(noValueSizeValidator.validate('aaa'));
+    const noArgSizeValidator = new Size();
+    assert.isNotTrue(noArgSizeValidator.impliesRequired);
+    assert.isTrue(noArgSizeValidator.validate(''));
+    assert.isTrue(noArgSizeValidator.validate('aaa'));
   });
 
   it('Digits', () => {


### PR DESCRIPTION
According to https://beanvalidation.org/2.0-jsr380/spec/#builtinconstraints-size, both `min` and `max` parameters of the `Size` constraint are optional, therefore it is possible to declare empty `@Size` without arguments. However, the corresponding `Size` model always requied an object argument.

This change makes the `Size` form validator argument optional, and enables using `new Size()` model validator without arguments corresponding to the empty `@Size` annotation in Java.