### PR TITLE
refactor(java/parser-jvm-utils): use global relativeTo approach for PathManager

### DIFF
--- a/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/EndpointProcessor.ts
@@ -13,7 +13,7 @@ export default class EndpointProcessor {
   readonly #dependencies = new DependencyManager(new PathManager());
   readonly #methods = new Map<string, ReadonlyDeep<OpenAPIV3.PathItemObject>>();
   readonly #name: string;
-  readonly #sourcePaths = new PathManager('ts');
+  readonly #sourcePaths = new PathManager({ extension: 'ts' });
 
   public constructor(name: string, context: BackbonePluginContext) {
     this.#context = context;

--- a/packages/ts/generator-typescript-plugin-backbone/src/TypeSchemaProcessor.ts
+++ b/packages/ts/generator-typescript-plugin-backbone/src/TypeSchemaProcessor.ts
@@ -55,12 +55,10 @@ export default class TypeSchemaProcessor {
   public declare ['constructor']: typeof TypeSchemaProcessor;
   readonly #dependencies: DependencyManager;
   readonly #schema: Schema;
-  readonly #cwd: string;
 
-  public constructor(schema: Schema, dependencies: DependencyManager, cwd = '.') {
+  public constructor(schema: Schema, dependencies: DependencyManager) {
     this.#schema = schema;
     this.#dependencies = dependencies;
-    this.#cwd = cwd;
   }
 
   public process(): readonly TypeNode[] {
@@ -88,7 +86,7 @@ export default class TypeSchemaProcessor {
   }
 
   #processArray(schema: ArraySchema): TypeNode {
-    const nodes = new TypeSchemaProcessor(schema.items, this.#dependencies, this.#cwd).process();
+    const nodes = new TypeSchemaProcessor(schema.items, this.#dependencies).process();
 
     return ts.factory.createTypeReferenceNode('Array', [ts.factory.createUnionTypeNode(nodes)]);
   }
@@ -97,7 +95,7 @@ export default class TypeSchemaProcessor {
     let valuesTypeNode: TypeNode;
 
     if (typeof valuesType !== 'boolean') {
-      const nodes = new TypeSchemaProcessor(valuesType, this.#dependencies, this.#cwd).process();
+      const nodes = new TypeSchemaProcessor(valuesType, this.#dependencies).process();
       valuesTypeNode = ts.factory.createUnionTypeNode(nodes);
     } else {
       valuesTypeNode = ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
@@ -113,7 +111,7 @@ export default class TypeSchemaProcessor {
     const { imports, paths } = this.#dependencies;
 
     const specifier = convertReferenceSchemaToSpecifier(schema);
-    const path = paths.createRelativePath(convertReferenceSchemaToPath(schema), this.#cwd);
+    const path = paths.createRelativePath(convertReferenceSchemaToPath(schema));
 
     const identifier = imports.default.getIdentifier(path) ?? imports.default.add(path, specifier, true);
 


### PR DESCRIPTION
Removes the necessity to use `#cwd` property